### PR TITLE
Add a customizable banner

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1088,7 +1088,7 @@ public class InAppBrowser extends CordovaPlugin {
                 // Add custom message!
                 RelativeLayout messageBanner = new RelativeLayout(cordova.getActivity());
                 messageBanner.setBackgroundColor(toolbarColor);  // or some other color?
-                messageBanner.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, this.dpToPixels(44)));
+                messageBanner.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, this.dpToPixels(48)));
                 messageBanner.setPadding(this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2));
                 messageBanner.setHorizontalGravity(Gravity.LEFT);
                 messageBanner.setVerticalGravity(Gravity.TOP);
@@ -1096,9 +1096,9 @@ public class InAppBrowser extends CordovaPlugin {
                 messageText = new TextView(cordova.getActivity());
                 messageText.setText(customMessageText);
                 messageText.setTextSize(16);
-                messageText.setTextColor(android.graphics.Color.BLACK); // set this based on a config
+                messageText.setTextColor(android.graphics.Color.WHITE); // TODO: set this based on a config
                 messageText.setGravity(Gravity.LEFT);
-                messageText.setPadding(this.dpToPixels(10), 0, this.dpToPixels(10), 0);
+                messageText.setPadding(this.dpToPixels(8), 0, this.dpToPixels(8), 0);
 
                 messageBanner.addView(messageText);
                 main.addView(messageBanner);

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1088,17 +1088,18 @@ public class InAppBrowser extends CordovaPlugin {
                 // Add custom message!
                 RelativeLayout messageBanner = new RelativeLayout(cordova.getActivity());
                 messageBanner.setBackgroundColor(toolbarColor);  // or some other color?
-                messageBanner.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, this.dpToPixels(48)));
-                messageBanner.setPadding(this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2));
+                messageBanner.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
+                // NOTE: left, top, right, bottom
+                messageBanner.setPadding(this.dpToPixels(10), 0, this.dpToPixels(10), this.dpToPixels(6));
                 messageBanner.setHorizontalGravity(Gravity.LEFT);
                 messageBanner.setVerticalGravity(Gravity.TOP);
 
                 messageText = new TextView(cordova.getActivity());
                 messageText.setText(customMessageText);
                 messageText.setTextSize(16);
-                messageText.setTextColor(android.graphics.Color.WHITE); // TODO: set this based on a config
+                // TODO: set this based on a config
+                messageText.setTextColor(android.graphics.Color.WHITE); 
                 messageText.setGravity(Gravity.LEFT);
-                messageText.setPadding(this.dpToPixels(8), 0, this.dpToPixels(8), 0);
 
                 messageBanner.addView(messageText);
                 main.addView(messageBanner);

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1102,12 +1102,10 @@ public class InAppBrowser extends CordovaPlugin {
                 messageText.setTextColor(android.graphics.Color.WHITE); 
                 messageText.setGravity(Gravity.LEFT);
 
-                // Initialize a click event for the banner. The listener needs to be replaced 
-                // each time the url changes.
                 messageText.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        sendCustomMessageTapped(url);
+                        sendCustomMessageTapped();
                     }
                 });
 
@@ -1171,11 +1169,11 @@ public class InAppBrowser extends CordovaPlugin {
         }
     }
 
-    private boolean sendCustomMessageTapped(String url) {
+    private boolean sendCustomMessageTapped() {
         try {
             JSONObject obj = new JSONObject();
             obj.put("type", CUSTOM_MESSAGE_TAPPED_EVENT);
-            obj.put("url", url);
+            obj.put("url", inAppWebView.getUrl());
             sendUpdate(obj, true);
             return true;
         } catch (JSONException ex) {
@@ -1483,15 +1481,6 @@ public class InAppBrowser extends CordovaPlugin {
             } catch (JSONException ex) {
                 LOG.e(LOG_TAG, "URI passed in has caused a JSON error.");
             }
-
-            // Update the custom-message banner click handler such that it will raise
-            // an event with the new URL.
-            messageText.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    sendCustomMessageTapped(url);
-                }
-            });
         }
 
         public void onPageFinished(WebView view, String url) {

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1125,8 +1125,6 @@ public class InAppBrowser extends CordovaPlugin {
 
                 // Set up the customizable banner.
                 RelativeLayout bannerLayout = new RelativeLayout(cordova.getActivity());
-
-                // Use the same background color as used for the toolbar.
                 bannerLayout.setBackgroundColor(bannerColor);
                 bannerLayout.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT));
                 // NOTE: Padding uses the format: left, top, right, bottom.
@@ -1150,7 +1148,6 @@ public class InAppBrowser extends CordovaPlugin {
                 if (showBanner) {
                     main.addView(bannerLayout);
                 }
-                
 
                 // Add our webview to our main view/layout
                 RelativeLayout webViewLayout = new RelativeLayout(cordova.getActivity());

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -120,12 +120,14 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String FOOTER_COLOR = "footercolor";
     private static final String BEFORELOAD = "beforeload";
     private static final String FULLSCREEN = "fullscreen";
+    private static final String CUSTOM_MESSAGE_TEXT = "custommessagetext";
 
-    private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR);
+    private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR, CUSTOM_MESSAGE_TEXT);
 
     private InAppBrowserDialog dialog;
     private WebView inAppWebView;
     private EditText edittext;
+    private TextView messageText;
     private CallbackContext callbackContext;
     private boolean showLocationBar = true;
     private boolean showZoomControls = true;
@@ -153,6 +155,7 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean fullscreen = true;
     private String[] allowedSchemes;
     private InAppBrowserClient currentClient;
+    private String customMessageText = "";
 
     /**
      * Executes the request and returns PluginResult.
@@ -333,6 +336,18 @@ public class InAppBrowser extends CordovaPlugin {
                     if (dialog != null && !cordova.getActivity().isFinishing()) {
                         dialog.hide();
                     }
+                }
+            });
+            PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
+            pluginResult.setKeepCallback(true);
+            this.callbackContext.sendPluginResult(pluginResult);
+        }
+        else if (action.equals("setCustomMessage")) {
+            final String newMessage = args.getString(0);
+            this.cordova.getActivity().runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    messageText.setText(newMessage);
                 }
             });
             PluginResult pluginResult = new PluginResult(PluginResult.Status.OK);
@@ -721,6 +736,10 @@ public class InAppBrowser extends CordovaPlugin {
             if (fullscreenSet != null) {
                 fullscreen = fullscreenSet.equals("yes") ? true : false;
             }
+            String customMessageTextSet = features.get(CUSTOM_MESSAGE_TEXT);
+            if (customMessageTextSet != null) {
+                customMessageText = customMessageTextSet;
+            }
         }
 
         final CordovaWebView thatWebView = this.webView;
@@ -1074,8 +1093,8 @@ public class InAppBrowser extends CordovaPlugin {
                 messageBanner.setHorizontalGravity(Gravity.LEFT);
                 messageBanner.setVerticalGravity(Gravity.TOP);
 
-                TextView messageText = new TextView(cordova.getActivity());
-                messageText.setText("This is a custom message!");
+                messageText = new TextView(cordova.getActivity());
+                messageText.setText(customMessageText);
                 messageText.setTextSize(16);
                 messageText.setTextColor(android.graphics.Color.BLACK); // set this based on a config
                 messageText.setGravity(Gravity.LEFT);

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1066,6 +1066,24 @@ public class InAppBrowser extends CordovaPlugin {
                     main.addView(toolbar);
                 }
 
+                // Add custom message!
+                RelativeLayout messageBanner = new RelativeLayout(cordova.getActivity());
+                messageBanner.setBackgroundColor(toolbarColor);  // or some other color?
+                messageBanner.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, this.dpToPixels(44)));
+                messageBanner.setPadding(this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2), this.dpToPixels(2));
+                messageBanner.setHorizontalGravity(Gravity.LEFT);
+                messageBanner.setVerticalGravity(Gravity.TOP);
+
+                TextView messageText = new TextView(cordova.getActivity());
+                messageText.setText("This is a custom message!");
+                messageText.setTextSize(16);
+                messageText.setTextColor(android.graphics.Color.BLACK); // set this based on a config
+                messageText.setGravity(Gravity.LEFT);
+                messageText.setPadding(this.dpToPixels(10), 0, this.dpToPixels(10), 0);
+
+                messageBanner.addView(messageText);
+                main.addView(messageBanner);
+
                 // Add our webview to our main view/layout
                 RelativeLayout webViewLayout = new RelativeLayout(cordova.getActivity());
                 webViewLayout.addView(inAppWebView);

--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -121,6 +121,7 @@ public class InAppBrowser extends CordovaPlugin {
     private static final String BEFORELOAD = "beforeload";
     private static final String FULLSCREEN = "fullscreen";
     private static final String CUSTOM_MESSAGE_TEXT = "custommessagetext";
+    private static final String CUSTOM_MESSAGE_TAPPED_EVENT = "custommessagetapped";
 
     private static final List customizableOptions = Arrays.asList(CLOSE_BUTTON_CAPTION, TOOLBAR_COLOR, NAVIGATION_COLOR, CLOSE_BUTTON_COLOR, FOOTER_COLOR, CUSTOM_MESSAGE_TEXT);
 
@@ -1101,6 +1102,15 @@ public class InAppBrowser extends CordovaPlugin {
                 messageText.setTextColor(android.graphics.Color.WHITE); 
                 messageText.setGravity(Gravity.LEFT);
 
+                // Initialize a click event for the banner. The listener needs to be replaced 
+                // each time the url changes.
+                messageText.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        sendCustomMessageTapped(url);
+                    }
+                });
+
                 messageBanner.addView(messageText);
                 main.addView(messageBanner);
 
@@ -1159,6 +1169,19 @@ public class InAppBrowser extends CordovaPlugin {
                 callbackContext = null;
             }
         }
+    }
+
+    private boolean sendCustomMessageTapped(String url) {
+        try {
+            JSONObject obj = new JSONObject();
+            obj.put("type", CUSTOM_MESSAGE_TAPPED_EVENT);
+            obj.put("url", url);
+            sendUpdate(obj, true);
+            return true;
+        } catch (JSONException ex) {
+            LOG.e(LOG_TAG, "URI passed in has caused a JSON error.");
+        }
+        return false;
     }
 
     /**
@@ -1460,6 +1483,15 @@ public class InAppBrowser extends CordovaPlugin {
             } catch (JSONException ex) {
                 LOG.e(LOG_TAG, "URI passed in has caused a JSON error.");
             }
+
+            // Update the custom-message banner click handler such that it will raise
+            // an event with the new URL.
+            messageText.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    sendCustomMessageTapped(url);
+                }
+            });
         }
 
         public void onPageFinished(WebView view, String url) {

--- a/src/ios/CDVInAppBrowserOptions.h
+++ b/src/ios/CDVInAppBrowserOptions.h
@@ -46,8 +46,11 @@
 @property (nonatomic, copy) NSString* beforeload;
 
 // Propel customized properties
-@property (nonatomic, assign) BOOL custommessage;
-@property (nonatomic, copy) NSString* custommessagetext;
+@property (nonatomic, assign) BOOL banner;
+@property (nonatomic, copy) NSString* bannercolor;
+@property (nonatomic, copy) NSString* bannermessage;
+@property (nonatomic, copy) NSString* bannertextcolor;
+@property (nonatomic, copy) NSString* bannertextsize;
 
 + (CDVInAppBrowserOptions*)parseOptions:(NSString*)options;
 

--- a/src/ios/CDVInAppBrowserOptions.h
+++ b/src/ios/CDVInAppBrowserOptions.h
@@ -45,6 +45,10 @@
 @property (nonatomic, assign) BOOL disallowoverscroll;
 @property (nonatomic, copy) NSString* beforeload;
 
+// Propel customized properties
+@property (nonatomic, assign) BOOL custommessage;
+@property (nonatomic, copy) NSString* custommessagetext;
+
 + (CDVInAppBrowserOptions*)parseOptions:(NSString*)options;
 
 @end

--- a/src/ios/CDVInAppBrowserOptions.m
+++ b/src/ios/CDVInAppBrowserOptions.m
@@ -46,8 +46,11 @@
         self.toolbartranslucent = YES;
         self.beforeload = @"";
 
-        self.custommessage = NO;
-        self.custommessagetext = @"";
+        self.banner = NO;
+        self.bannermessage = @"";
+        self.bannercolor = @"#CCCCCC";
+        self.bannertextcolor = @"#000000";
+        self.bannertextsize = @"16";
     }
 
     return self;

--- a/src/ios/CDVInAppBrowserOptions.m
+++ b/src/ios/CDVInAppBrowserOptions.m
@@ -45,6 +45,9 @@
         self.toolbarcolor = nil;
         self.toolbartranslucent = YES;
         self.beforeload = @"";
+
+        self.custommessage = NO;
+        self.custommessagetext = @"";
     }
 
     return self;

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -61,7 +61,7 @@
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* closeButton;
 @property (nonatomic, strong) IBOutlet UILabel* addressLabel;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* backButton;
-@property (nonatomic, strong) IBOutlet UILabel* customMessageLabel;
+@property (nonatomic, strong) IBOutlet UITextView* customMessageLabel;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* forwardButton;
 @property (nonatomic, strong) IBOutlet UIActivityIndicatorView* spinner;
 @property (nonatomic, strong) IBOutlet UIToolbar* toolbar;

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -43,6 +43,7 @@
 - (void)open:(CDVInvokedUrlCommand*)command;
 - (void)close:(CDVInvokedUrlCommand*)command;
 - (void)injectScriptCode:(CDVInvokedUrlCommand*)command;
+- (void)setCustomMessage:(CDVInvokedUrlCommand*)command;
 - (void)show:(CDVInvokedUrlCommand*)command;
 - (void)hide:(CDVInvokedUrlCommand*)command;
 - (void)loadAfterBeforeload:(CDVInvokedUrlCommand*)command;
@@ -60,6 +61,7 @@
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* closeButton;
 @property (nonatomic, strong) IBOutlet UILabel* addressLabel;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* backButton;
+@property (nonatomic, strong) IBOutlet UILabel* customMessageLabel;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* forwardButton;
 @property (nonatomic, strong) IBOutlet UIActivityIndicatorView* spinner;
 @property (nonatomic, strong) IBOutlet UIToolbar* toolbar;
@@ -73,7 +75,9 @@
 - (void)navigateTo:(NSURL*)url;
 - (void)showLocationBar:(BOOL)show;
 - (void)showToolBar:(BOOL)show : (NSString *) toolbarPosition;
+- (void)showCustomMessage:(BOOL)show;
 - (void)setCloseButtonTitle:(NSString*)title : (NSString*) colorString : (int) buttonIndex;
+- (void)setCustomMessageLabelText:(NSString*)message;
 
 - (id)initWithBrowserOptions: (CDVInAppBrowserOptions*) browserOptions andSettings:(NSDictionary*) settings;
 

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -43,11 +43,11 @@
 - (void)open:(CDVInvokedUrlCommand*)command;
 - (void)close:(CDVInvokedUrlCommand*)command;
 - (void)injectScriptCode:(CDVInvokedUrlCommand*)command;
-- (void)setCustomMessage:(CDVInvokedUrlCommand*)command;
+- (void)setBannerMessage:(CDVInvokedUrlCommand*)command;
 - (void)show:(CDVInvokedUrlCommand*)command;
 - (void)hide:(CDVInvokedUrlCommand*)command;
 - (void)loadAfterBeforeload:(CDVInvokedUrlCommand*)command;
-- (void)sendCustomMessageTapped:(NSString *)url;
+- (void)sendBannerTappedEvent:(NSString *)url;
 
 @end
 
@@ -62,7 +62,7 @@
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* closeButton;
 @property (nonatomic, strong) IBOutlet UILabel* addressLabel;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* backButton;
-@property (nonatomic, strong) IBOutlet UITextView* customMessageLabel;
+@property (nonatomic, strong) IBOutlet UITextView* bannerTextView;
 @property (nonatomic, strong) IBOutlet UIBarButtonItem* forwardButton;
 @property (nonatomic, strong) IBOutlet UIActivityIndicatorView* spinner;
 @property (nonatomic, strong) IBOutlet UIToolbar* toolbar;
@@ -76,10 +76,10 @@
 - (void)navigateTo:(NSURL*)url;
 - (void)showLocationBar:(BOOL)show;
 - (void)showToolBar:(BOOL)show : (NSString *) toolbarPosition;
-- (void)showCustomMessage:(BOOL)show;
+- (void)showBanner:(BOOL)show;
 - (void)setCloseButtonTitle:(NSString*)title : (NSString*) colorString : (int) buttonIndex;
-- (void)setCustomMessageLabelText:(NSString*)message;
-- (void)textViewTapped:(UITapGestureRecognizer *)tap;
+- (void)setBannerTextViewText:(NSString*)message;
+- (void)bannerTextViewTapped:(UITapGestureRecognizer *)tap;
 
 - (id)initWithBrowserOptions: (CDVInAppBrowserOptions*) browserOptions andSettings:(NSDictionary*) settings;
 

--- a/src/ios/CDVWKInAppBrowser.h
+++ b/src/ios/CDVWKInAppBrowser.h
@@ -47,6 +47,7 @@
 - (void)show:(CDVInvokedUrlCommand*)command;
 - (void)hide:(CDVInvokedUrlCommand*)command;
 - (void)loadAfterBeforeload:(CDVInvokedUrlCommand*)command;
+- (void)sendCustomMessageTapped:(NSString *)url;
 
 @end
 
@@ -78,6 +79,7 @@
 - (void)showCustomMessage:(BOOL)show;
 - (void)setCloseButtonTitle:(NSString*)title : (NSString*) colorString : (int) buttonIndex;
 - (void)setCustomMessageLabelText:(NSString*)message;
+- (void)textViewTapped:(UITapGestureRecognizer *)tap;
 
 - (id)initWithBrowserOptions: (CDVInAppBrowserOptions*) browserOptions andSettings:(NSDictionary*) settings;
 

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -855,22 +855,20 @@ BOOL isExiting = FALSE;
     self.bannerTextView.contentMode = UIViewContentModeScaleToFill;
     self.bannerTextView.editable = NO;
     self.bannerTextView.hidden = NO;
-
     self.bannerTextView.multipleTouchEnabled = NO;
     self.bannerTextView.opaque = YES;
     self.bannerTextView.scrollEnabled = NO;
     self.bannerTextView.textAlignment = NSTextAlignmentLeft;
     self.bannerTextView.textColor = [self colorFromHexString:_browserOptions.bannertextcolor];
-    
-    [self.bannerTextView setFont:[UIFont systemFontOfSize:[_browserOptions.bannertextsize intValue]]];
     // NOTE: Edge format is top, left, bottom, right.
     self.bannerTextView.textContainerInset = UIEdgeInsetsMake(8, 5, 8, 5);
-
     self.bannerTextView.userInteractionEnabled = YES;
+    
+    [self.bannerTextView setFont:[UIFont systemFontOfSize:[_browserOptions.bannertextsize intValue]]];
 
     CGSize sizeThatFitsTextView = [self.bannerTextView sizeThatFits:CGSizeMake(self.bannerTextView.frame.size.width, CGFLOAT_MAX)];
     bannerFrame.size.height = sizeThatFitsTextView.height;
-    // adjust webview height accordingly
+    // Adjust webview height accordingly.
     webViewBounds.size.height -= _browserOptions.banner ? self.bannerTextView.frame.size.height : 0;
 
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(bannerTextViewTapped:)];
@@ -908,7 +906,7 @@ BOOL isExiting = FALSE;
     self.addressLabel.alpha = 1.000;
     self.addressLabel.autoresizesSubviews = YES;
     self.addressLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin;
-    // deal with transparent url bar issued based on https://github.com/apache/cordova-plugin-inappbrowser/issues/870
+    // Don't use transparent url bar - based on https://github.com/apache/cordova-plugin-inappbrowser/issues/870
     self.addressLabel.backgroundColor = [self colorFromHexString:_browserOptions.toolbarcolor];
     self.addressLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
     self.addressLabel.clearsContextBeforeDrawing = YES;
@@ -1113,8 +1111,6 @@ BOOL isExiting = FALSE;
     }
 }
 
-// Note: This method is incomplete, but should be OK as long as the custom message hidden state
-// is not changed after it is first created.
 - (void)showBanner:(BOOL)show
 {   
     // prevent double show/hide

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -208,7 +208,7 @@ static CDVWKInAppBrowser* instance = nil;
         }
     }
     
-    [self.inAppBrowserViewController showBanner:browserOptions.bannermessage];
+    [self.inAppBrowserViewController showBanner:browserOptions.banner];
     [self.inAppBrowserViewController showLocationBar:browserOptions.location];
     [self.inAppBrowserViewController showToolBar:browserOptions.toolbar :browserOptions.toolbarposition];
     if (browserOptions.closebuttoncaption != nil || browserOptions.closebuttoncolor != nil) {

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -36,7 +36,7 @@
 
 #define    IAB_BRIDGE_NAME @"cordova_iab"
 
-#define    CUSTOM_MESSAGE_HEIGHT 40.0
+#define    CUSTOM_MESSAGE_HEIGHT 54.0
 #define    TOOLBAR_HEIGHT 44.0
 #define    LOCATIONBAR_HEIGHT 21.0
 #define    FOOTER_HEIGHT ((TOOLBAR_HEIGHT) + (LOCATIONBAR_HEIGHT))
@@ -858,7 +858,8 @@ BOOL isExiting = FALSE;
     self.customMessageLabel.textColor = [UIColor colorWithWhite:1.000 alpha:1.000];
     
     [self.customMessageLabel setFont:[UIFont systemFontOfSize:16]];
-    self.customMessageLabel.textContainerInset = UIEdgeInsetsMake(8, 5, 0, 5);
+    // NOTE: top, left, bottom, right
+    self.customMessageLabel.textContainerInset = UIEdgeInsetsMake(8, 5, 8, 5);
     
     float toolbarY = toolbarIsAtBottom ? self.view.bounds.size.height - TOOLBAR_HEIGHT : CUSTOM_MESSAGE_HEIGHT;
     CGRect toolbarFrame = CGRectMake(0.0, toolbarY, self.view.bounds.size.width, TOOLBAR_HEIGHT);

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -703,6 +703,14 @@ static CDVWKInAppBrowser* instance = nil;
     _previousStatusBarStyle = -1; // this value was reset before reapplying it. caused statusbar to stay black on ios7
 }
 
+- (void)sendCustomMessageTapped:(NSString *)url {
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                            messageAsDictionary:@{@"type":@"custommessagetapped", @"url":url}];
+    [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+}
+
 @end //CDVWKInAppBrowser
 
 #pragma mark CDVWKInAppBrowserViewController
@@ -861,10 +869,17 @@ BOOL isExiting = FALSE;
     // NOTE: top, left, bottom, right
     self.customMessageLabel.textContainerInset = UIEdgeInsetsMake(8, 5, 8, 5);
 
+    self.customMessageLabel.userInteractionEnabled = YES;
+
     CGSize sizeThatFitsTextView = [self.customMessageLabel sizeThatFits:CGSizeMake(self.customMessageLabel.frame.size.width, CGFLOAT_MAX)];
     customMessageFrame.size.height = sizeThatFitsTextView.height;
     // adjust webview height accordingly
     webViewBounds.size.height -= _browserOptions.custommessage ? self.customMessageLabel.frame.size.height : 0;
+
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc]initWithTarget:self action:@selector(textViewTapped:)];
+    tap.delegate = self; 
+    tap.numberOfTapsRequired = 1; 
+    [self.customMessageLabel addGestureRecognizer:tap];
     
     float toolbarY = toolbarIsAtBottom ? self.view.bounds.size.height - TOOLBAR_HEIGHT : 0;
     CGRect toolbarFrame = CGRectMake(0.0, toolbarY, self.view.bounds.size.width, TOOLBAR_HEIGHT);
@@ -1201,6 +1216,11 @@ BOOL isExiting = FALSE;
     [self rePositionViews];
     
     [super viewWillAppear:animated];
+}
+
+- (void)textViewTapped:(UITapGestureRecognizer *)tap {
+    NSString* currentURL = [self.webView.URL absoluteString];
+    [self.navigationDelegate sendCustomMessageTapped:currentURL];
 }
 
 //

--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -36,7 +36,7 @@
 
 #define    IAB_BRIDGE_NAME @"cordova_iab"
 
-#define    CUSTOM_MESSAGE_HEIGHT 44.0
+#define    CUSTOM_MESSAGE_HEIGHT 40.0
 #define    TOOLBAR_HEIGHT 44.0
 #define    LOCATIONBAR_HEIGHT 21.0
 #define    FOOTER_HEIGHT ((TOOLBAR_HEIGHT) + (LOCATIONBAR_HEIGHT))
@@ -839,7 +839,7 @@ BOOL isExiting = FALSE;
     fixedSpaceButton.width = 20;
 
     CGRect customMessageFrame = CGRectMake(0.0, 0.0, self.view.bounds.size.width, CUSTOM_MESSAGE_HEIGHT);
-    self.customMessageLabel = [[UILabel alloc] initWithFrame:customMessageFrame];
+    self.customMessageLabel = [[UITextView alloc] initWithFrame:customMessageFrame];
     self.customMessageLabel.alpha = 1.000;
     self.customMessageLabel.autoresizesSubviews = YES;
     self.customMessageLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
@@ -847,26 +847,18 @@ BOOL isExiting = FALSE;
     self.customMessageLabel.clearsContextBeforeDrawing = YES;
     self.customMessageLabel.clipsToBounds = YES;
     self.customMessageLabel.contentMode = UIViewContentModeScaleToFill;
-    self.customMessageLabel.enabled = YES;
+    self.customMessageLabel.editable = NO;
     self.customMessageLabel.hidden = NO;
-    self.customMessageLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-
-    if ([self.customMessageLabel respondsToSelector:NSSelectorFromString(@"setMinimumScaleFactor:")]) {
-        [self.customMessageLabel setValue:@(10.0/[UIFont labelFontSize]) forKey:@"minimumScaleFactor"];
-    } else if ([self.customMessageLabel respondsToSelector:NSSelectorFromString(@"setMinimumFontSize:")]) {
-        [self.customMessageLabel setValue:@(10.0) forKey:@"minimumFontSize"];
-    }
 
     self.customMessageLabel.multipleTouchEnabled = NO;
-    self.customMessageLabel.numberOfLines = 1;
     self.customMessageLabel.opaque = YES;
-    self.customMessageLabel.shadowOffset = CGSizeMake(0.0, -1.0);
     // self.customMessageLabel.text = @"";  // this will get set later
     self.customMessageLabel.textAlignment = NSTextAlignmentLeft;
-
     // TODO: Make text color configurable.
     self.customMessageLabel.textColor = [UIColor colorWithWhite:1.000 alpha:1.000];
-    self.customMessageLabel.userInteractionEnabled = NO;
+    
+    [self.customMessageLabel setFont:[UIFont systemFontOfSize:16]];
+    self.customMessageLabel.textContainerInset = UIEdgeInsetsMake(8, 5, 0, 5);
     
     float toolbarY = toolbarIsAtBottom ? self.view.bounds.size.height - TOOLBAR_HEIGHT : CUSTOM_MESSAGE_HEIGHT;
     CGRect toolbarFrame = CGRectMake(0.0, toolbarY, self.view.bounds.size.width, TOOLBAR_HEIGHT);

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -34,7 +34,7 @@
             exit: channel.create('exit'),
             customscheme: channel.create('customscheme'),
             message: channel.create('message'),
-            custommessagetapped: channel.create("custommessagetapped")
+            bannertapped: channel.create("bannertapped")
         };
     }
 
@@ -92,8 +92,8 @@
             }
         },
 
-        setCustomMessage: function (message, cb) {
-            exec(cb, null, 'InAppBrowser', 'setCustomMessage', [message, !!cb]);
+        setBannerMessage: function (message, cb) {
+            exec(cb, null, 'InAppBrowser', 'setBannerMessage', [message, !!cb]);
         }
     };
 

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -33,7 +33,8 @@
             loaderror: channel.create('loaderror'),
             exit: channel.create('exit'),
             customscheme: channel.create('customscheme'),
-            message: channel.create('message')
+            message: channel.create('message'),
+            custommessagetapped: channel.create("custommessagetapped")
         };
     }
 

--- a/www/inappbrowser.js
+++ b/www/inappbrowser.js
@@ -89,6 +89,10 @@
             } else {
                 throw new Error('insertCSS requires exactly one of code or file to be specified');
             }
+        },
+
+        setCustomMessage: function (message, cb) {
+            exec(cb, null, 'InAppBrowser', 'setCustomMessage', [message, !!cb]);
         }
     };
 


### PR DESCRIPTION
Create a customizable "banner" that can be shown at the top of the in-app-browser. The following new options can be set on `open()`:
- **banner**: set to `yes` to show the banner. The default value is `no`.
- **bannermessage**: the text to display in the banner
- **bannercolor**: the banner background color
- **bannertextcolor**: the banner text color
- **bannertextsize**: the banner text size

The method `browser.setBannerMessage()` can be used at any time to update the banner message.

A new event called `bannertapped` is raised whenever the banner area is tapped by the user.

----

![image](https://user-images.githubusercontent.com/1410664/125530655-77124e82-4fd4-4762-b952-f0c8fa98aaa1.png) 
![image](https://user-images.githubusercontent.com/1410664/125530679-7ba80c5e-a9d9-4e06-b300-91c5d88bd1e5.png)