### PR TITLE
Disable iOS banner interaction

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -862,7 +862,7 @@ BOOL isExiting = FALSE;
     self.bannerTextView.textColor = [self colorFromHexString:_browserOptions.bannertextcolor];
     // NOTE: Edge format is top, left, bottom, right.
     self.bannerTextView.textContainerInset = UIEdgeInsetsMake(8, 5, 8, 5);
-    self.bannerTextView.userInteractionEnabled = YES;
+    self.bannerTextView.userInteractionEnabled = NO;
     
     [self.bannerTextView setFont:[UIFont systemFontOfSize:[_browserOptions.bannertextsize intValue]]];
 


### PR DESCRIPTION
Selecting text in the banner works weirdly when "tapping" to raise the tap event. Android also doesn't allow text selection.