### PR TITLE
Reduce webview size by banner height on iOS

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -1235,6 +1235,9 @@ BOOL isExiting = FALSE;
         self.bannerTextView.frame = CGRectMake(self.bannerTextView.frame.origin.x, statusBarHeight, self.bannerTextView.frame.size.width, sizeThatFitsTextView.height);
 
         viewBounds.origin.y += self.bannerTextView.frame.size.height;
+
+        viewBounds.size.height = viewBounds.size.height - self.bannerTextView.frame.size.height;
+        lastReducedStatusBarHeight = lastReducedStatusBarHeight + self.bannerTextView.frame.size.height;
     }
     
     if ((_browserOptions.toolbar) && ([_browserOptions.toolbarposition isEqualToString:kInAppBrowserToolbarBarPositionTop])) {


### PR DESCRIPTION
On iOS, the webview height currently doesn't take into account the height of the banner, which means you are unable to scroll all the way to the bottom of a page or access any links there.

This change should fix the issue such that the webview ends right where the location bar begins. Tested both on initial load and setting the banner via `iab.setBannerMessage()`.

Will need to update the CMS contents to revise the button placement after this starts going out.