### PR TITLE
Add null check for navigationButtonColor

### DIFF
--- a/src/android/InAppBrowser.java
+++ b/src/android/InAppBrowser.java
@@ -1042,7 +1042,7 @@ public class InAppBrowser extends CordovaPlugin {
                 pageTitleTextView.setLayoutParams(pageTitleTextViewLayoutParams);
                 pageTitleTextView.setText("Loading...");
                 pageTitleTextView.setTextSize(bannerTextSize);
-                pageTitleTextView.setTextColor(android.graphics.Color.parseColor(navigationButtonColor));
+                if (navigationButtonColor != "") pageTitleTextView.setTextColor(android.graphics.Color.parseColor(navigationButtonColor));
                 pageTitleTextView.setTypeface(null, Typeface.BOLD);
                 int lockResId = activityRes.getIdentifier("lock", "drawable", cordova.getActivity().getPackageName());
                 Drawable lockIcon = activityRes.getDrawable(lockResId);


### PR DESCRIPTION
This check should fix the Android IAB by adding a null check so it doesn't throw an exception when the value is not provided. https://propel-team.slack.com/archives/C0434Q1A1LL/p1684882333693259?thread_ts=1684877713.424789&cid=C0434Q1A1LL