### PR TITLE
Bring in upstream fix for external browser issue

### DIFF
--- a/src/ios/CDVWKInAppBrowser.m
+++ b/src/ios/CDVWKInAppBrowser.m
@@ -375,10 +375,12 @@ static CDVWKInAppBrowser* instance = nil;
 
 - (void)openInSystem:(NSURL*)url
 {
-    if ([[UIApplication sharedApplication] openURL:url] == NO) {
-        [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
-        [[UIApplication sharedApplication] openURL:url];
-    }
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:^(BOOL success) {
+        if (!success) {
+            [[NSNotificationCenter defaultCenter] postNotification:[NSNotification notificationWithName:CDVPluginHandleOpenURLNotification object:url]];
+            [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+        }
+    }];
 }
 
 - (void)loadAfterBeforeload:(CDVInvokedUrlCommand*)command


### PR DESCRIPTION
This is a git history nightmare. Instead of merging the original fixes to `master`, [this should have been the branch](https://github.com/propelinc/cordova-plugin-inappbrowser/pull/11) we applied new fixes on because this is the last version of the IAB we used.

But since Kyle did a bunch of testing with all the OS changes and [this commit included](https://github.com/propelinc/cordova-plugin-inappbrowser/commit/e81d69fd9b27a5721fb1dcd5243a5ef98e32dee5), I just applied the one change that makes external browsers work.

We really need to just delete this fork and start using the new IAB ASAP because I don't want to continue managing this insane fork.

Oh also [this is the fix](https://github.com/apache/cordova-ios/issues/1511) that was mentioned in the [original PR](https://github.com/propelinc/orchard/pull/4041) which is how I found it.